### PR TITLE
Add hibernate power state.

### DIFF
--- a/amt/wsman.py
+++ b/amt/wsman.py
@@ -28,6 +28,7 @@ POWER_STATES = {
     'off': 8,
     'standby': 4,
     'reboot': 5,
+    'hibernate': 7,
 }
 
 # Valid boot devices

--- a/tests/test_wsman.py
+++ b/tests/test_wsman.py
@@ -110,6 +110,10 @@ class TestFriendlyPowerState(testtools.TestCase):
         self.assertEqual(wsman.friendly_power_state('5'), 'reboot')
         self.assertEqual(wsman.friendly_power_state(5), 'reboot')
 
+    def test_hibernate(self):
+        self.assertEqual(wsman.friendly_power_state('7'), 'hibernate')
+        self.assertEqual(wsman.friendly_power_state(7), 'hibernate')
+
     def test_unknown(self):
         self.assertEqual(wsman.friendly_power_state('42'), 'unknown')
         self.assertEqual(wsman.friendly_power_state(42), 'unknown')


### PR DESCRIPTION
According to [Intel® AMT 9.0 Start Here Guide](https://software.intel.com/en-us/articles/intel-active-management-technology-start-here-guide-intel-amt-9)

> 7: Hibernate (Off Soft), corresponding to ACPI state S4, where the state of the managed element is preserved and will be recovered upon powering on

I also tested this with an Intel NUC I have access to, and after
asking the OS to hibernate the machine (and waiting for about 2
minutes) `amt.client.Clients.poser_status()` returned `'7'`.