### PR TITLE
Add initial VNC specific password functionality

### DIFF
--- a/amt/client.py
+++ b/amt/client.py
@@ -142,8 +142,8 @@ class Client(object):
             "PowerState")
         return value
 
-    def enable_vnc(self):
-        payload = amt.wsman.enable_remote_kvm(self.uri, self.password)
+    def enable_vnc(self, passwd):
+        payload = amt.wsman.enable_remote_kvm(self.uri, passwd)
         self.post(payload)
         payload = amt.wsman.kvm_redirect(self.uri)
         self.post(payload)

--- a/bin/amtctrl
+++ b/bin/amtctrl
@@ -3,6 +3,8 @@
 import argparse
 import os
 import sys
+import getpass
+import re
 
 import requests
 
@@ -61,6 +63,11 @@ def parse_args_rm():
                    help='')
     return parser.parse_args()
 
+def check_valid_vnc_password(passwd):
+    if re.search(r'^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8}\b$', passwd):
+        return True
+    else:
+        return False
 
 def main():
     args = parse_args()
@@ -78,8 +85,7 @@ def main():
     if args.prompt:
         host = args.server
         if sys.stdin.isatty():
-            from getpass import getpass
-            passwd = getpass()
+            passwd = getpass.getpass()
         else:
             passwd = sys.stdin.readline().rstrip('\r\n')
     else:
@@ -104,8 +110,28 @@ def main():
         elif args.command == "status":
            print(amt.wsman.friendly_power_state(client.power_status()))
         elif args.command == "vnc":
-             client.enable_vnc()
-             print("VNC enabled on port 5900 with AMT password")
+             if check_valid_vnc_password(passwd):
+                 vncpasswd = passwd
+             else:
+                 print('Warning, current AMT password does not meet RFBPassword complexity requirements.\n')
+                 print('Password must be EXACTLY 8 characters and have the following:')
+                 print('*) one upper case letter')
+                 print('*) one lower case letter')
+                 print('*) one digit')
+                 print('*) one special character excluding (") (,) (:)')
+                 
+                 while True:
+                     vncpasswd = getpass.getpass('VNC Password:')
+                     if check_valid_vnc_password(vncpasswd):
+                         break
+                     else:
+                         print('Invalid password')
+             client.enable_vnc(vncpasswd)
+             if vncpasswd == passwd:
+                 print("VNC enabled on port 5900 with AMT password")
+             else:
+                 print("VNC enabled on port 5900 with non-AMT VNC specific password")
+
         elif args.command == "vncstatus":
              print(client.vnc_status())
         else:


### PR DESCRIPTION
Without making changes to the existing argparse config, I wasn't sure of the best way to add a "prompt" flag for the vnc enable command.

This current PR will detect if the AMT password can't be used as a VNC password, and if so, will prompt the user for a VNC specific password.

@sdague lemme know your thoughts on this. I'm not really sold on ^this^ idea but I figured it would be a starting point at least.

Ref #24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/amt/25)
<!-- Reviewable:end -->
